### PR TITLE
mlr3survival -> mlr3proba

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     lgr,
     mlbench,
     mlr3filters,
-    mlr3survival,
+    mlr3proba,
     precrec,
     rpart,
     survival,
@@ -34,7 +34,7 @@ Suggests:
 Remotes:
     mlr-org/mlr3,
     mlr-org/mlr3filters,
-    mlr-org/mlr3survival
+    mlr-org/mlr3proba
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: no

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Encoding: UTF-8
 LazyData: true
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.0
+RoxygenNote: 7.0.1

--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -1,9 +1,9 @@
 #' @title Plot for Survival Tasks
 #'
 #' @description
-#' Generates plots for [mlr3survival::TaskSurv].
+#' Generates plots for [mlr3proba::TaskSurv].
 #'
-#' @param object ([mlr3survival::TaskSurv]).
+#' @param object ([mlr3proba::TaskSurv]).
 #' @param type (`character(1)`):
 #'   Type of the plot. Available choices:
 #'   * `"target"`: bar plot of target variable (default).
@@ -17,12 +17,12 @@
 #' @export
 #' @examples
 #' library(mlr3)
-#' library(mlr3survival)
+#' library(mlr3proba)
 #' task = mlr_tasks$get("lung")
 #'
 #' head(fortify(task))
 #' autoplot(task)
-#' autoplot(task, strata = "sex")
+#' autoplot(task, rhs = "sex")
 #' autoplot(task, type = "duo")
 autoplot.TaskSurv = function(object, type = "target", ...) {
   assert_choice(type, c("target", "pairs", "duo"))
@@ -30,8 +30,12 @@ autoplot.TaskSurv = function(object, type = "target", ...) {
 
   if (type == "target") {
     require_namespaces(c("survival", "GGally"))
-    GGally::ggsurv(object$survfit(...))
-  } else if (type == "pairs") {
+    if(length(list(...))==0)
+      GGally::ggsurv(invoke(survival::survfit, formula = task$formula(1), data = task$data()))
+    else
+      GGally::ggsurv(invoke(survival::survfit, formula = task$formula(...), data = task$data()))
+  } else
+    if (type == "pairs") {
     require_namespaces("GGally")
     GGally::ggpairs(object, ...)
   } else {

--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -31,9 +31,9 @@ autoplot.TaskSurv = function(object, type = "target", ...) {
   if (type == "target") {
     require_namespaces(c("survival", "GGally"))
     if(length(list(...))==0)
-      GGally::ggsurv(invoke(survival::survfit, formula = task$formula(1), data = task$data()))
+      GGally::ggsurv(invoke(survival::survfit, formula = object$formula(1), data = object$data()))
     else
-      GGally::ggsurv(invoke(survival::survfit, formula = task$formula(...), data = task$data()))
+      GGally::ggsurv(invoke(survival::survfit, formula = object$formula(...), data = object$data()))
   } else
     if (type == "pairs") {
     require_namespaces("GGally")

--- a/man/autoplot.TaskSurv.Rd
+++ b/man/autoplot.TaskSurv.Rd
@@ -7,7 +7,7 @@
 \method{autoplot}{TaskSurv}(object, type = "target", ...)
 }
 \arguments{
-\item{object}{(\link[mlr3survival:TaskSurv]{mlr3survival::TaskSurv}).}
+\item{object}{(\link[mlr3proba:TaskSurv]{mlr3proba::TaskSurv}).}
 
 \item{type}{(\code{character(1)}):
 Type of the plot. Available choices:
@@ -26,15 +26,15 @@ Additional argument, possibly passed down to the underlying plot functions.}
 \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 }
 \description{
-Generates plots for \link[mlr3survival:TaskSurv]{mlr3survival::TaskSurv}.
+Generates plots for \link[mlr3proba:TaskSurv]{mlr3proba::TaskSurv}.
 }
 \examples{
 library(mlr3)
-library(mlr3survival)
+library(mlr3proba)
 task = mlr_tasks$get("lung")
 
 head(fortify(task))
 autoplot(task)
-autoplot(task, strata = "sex")
+autoplot(task, rhs = "sex")
 autoplot(task, type = "duo")
 }

--- a/tests/testthat/test_TaskSurv.R
+++ b/tests/testthat/test_TaskSurv.R
@@ -2,7 +2,7 @@ context("TaskSurv")
 
 
 test_that("autoplot.TaskSurv", {
-  requireNamespace("mlr3survival")
+  requireNamespace("mlr3proba")
   task = mlr_tasks$get("rats")
   p = autoplot(task)
   expect_true(is.ggplot(p))


### PR DESCRIPTION
The changes made aren't really ideal but because `mlr3survival` included `survfit` in the task but `mlr3proba` does not, I had to add a hacky workaround to keep the nice plotting. The only API difference is changing the extra optional argument `strata` to `rhs`