### PR TITLE
autoplot.ResampleResult type=prediction: manual color scale

### DIFF
--- a/R/ResampleResult.R
+++ b/R/ResampleResult.R
@@ -152,9 +152,12 @@ plot_learner_prediction_resample_result = function(object, predict_sets, grid_po
     if (task_type == "classif" && learners[[1L]]$predict_type == "prob") {
       raster_aes = aes_string(fill = "response", alpha = ".prob.response")
       scale_alpha = scale_alpha_continuous(name = "Prob.")
+      scale_fill = NULL
     } else {
       raster_aes = aes_string(fill = "response")
       scale_alpha = NULL
+      # manual values for RColorBrewer::brewer.pal(11, "Spectral")
+      scale_fill = scale_fill_gradientn(colours = c("#9E0142", "#D53E4F", "#F46D43", "#FDAE61", "#FEE08B", "#FFFFBF", "#E6F598", "#ABDDA4", "#66C2A5", "#3288BD", "#5E4FA2"))
     }
 
     g = ggplot(grid, aes_string(features[1L], features[2L])) +
@@ -162,6 +165,7 @@ plot_learner_prediction_resample_result = function(object, predict_sets, grid_po
       geom_point(data = task_data(object, predict_sets), aes_string(fill = task$target_names, shape = ".predict_set"), color = "black") +
       scale_shape_manual(values = c(train = 21, test = 22, both = 23), name = "Set") +
       scale_alpha +
+      scale_fill +
       labs(fill = "Response") +
       folds_facet
   }

--- a/R/ResampleResult.R
+++ b/R/ResampleResult.R
@@ -156,8 +156,9 @@ plot_learner_prediction_resample_result = function(object, predict_sets, grid_po
     } else {
       raster_aes = aes_string(fill = "response")
       scale_alpha = NULL
-      # manual values for RColorBrewer::brewer.pal(11, "Spectral")
-      scale_fill = scale_fill_gradientn(colours = c("#9E0142", "#D53E4F", "#F46D43", "#FDAE61", "#FEE08B", "#FFFFBF", "#E6F598", "#ABDDA4", "#66C2A5", "#3288BD", "#5E4FA2"))
+      # manual values for rev(RColorBrewer::brewer.pal(11, "Spectral"))
+      scale_fill = scale_fill_gradientn(colours = c("#5E4FA2", "#3288BD", "#66C2A5", "#ABDDA4", "#E6F598", "#FFFFBF", "#FEE08B", "#FDAE61", "#F46D43", "#D53E4F", "#9E0142")
+)
     }
 
     g = ggplot(grid, aes_string(features[1L], features[2L])) +


### PR DESCRIPTION
Not completely colorblind friendly but with diverging colors witch easily allows to see outliers.

```r
library(mlr3)
library(mlr3learners)
library(mlr3viz)
task3 = tsk("boston_housing")$clone()$select(c("lat", "lon"))
learner = lrn("regr.km", scaling = TRUE, nugget.estim = TRUE)$train(task3)
res = resample(task3, learner, resampling = rsmp("holdout", ratio = 0.5), store_models = TRUE)
autoplot(res, type = "prediction")
```
![grafik](https://user-images.githubusercontent.com/1888623/74910089-fb655a00-53b9-11ea-8910-efa2e68971cc.png)


If somebody needs another scale (s)he can easily overwrite the scale.