### PR TITLE
`autoplot.BenchmarResult()`: Support for learners with identical IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,17 +2,22 @@ Package: mlr3viz
 Title: Visualizations for 'mlr3'
 Version: 0.1.1.9000
 Authors@R:
-    person(given = "Michel",
-           family = "Lang",
-           role = c("cre", "aut"),
-           email = "michellang@gmail.com",
-           comment = c(ORCID = "0000-0001-9754-0393"))
-Description: Provides visualizations for 'mlr3' objects such as tasks,
-    predictions, resample results or benchmark results via the autoplot()
-    generic of 'ggplot2'. The returned 'ggplot' objects are intended to provide
-    sensible defaults, yet can easily be customized to create camera-ready
-    figures. Visualizations include barplots, boxplots, histograms, ROC curves,
-    and Precision-Recall curves.
+    c(person(given = "Michel",
+             family = "Lang",
+             role = c("cre", "aut"),
+             email = "michellang@gmail.com",
+             comment = c(ORCID = "0000-0001-9754-0393")),
+      person(given = "Patrick",
+             family = "Schratz",
+             role = "aut",
+             email = "patrick.schratz@gmail.com",
+             comment = c(ORCID = "0000-0003-0748-6624")))
+Description: Provides visualizations for 'mlr3' objects such as
+    tasks, predictions, resample results or benchmark results via the
+    autoplot() generic of 'ggplot2'. The returned 'ggplot' objects are
+    intended to provide sensible defaults, yet can easily be customized to
+    create camera-ready figures. Visualizations include barplots,
+    boxplots, histograms, ROC curves, and Precision-Recall curves.
 License: LGPL-3
 URL: https://mlr3viz.mlr-org.com,
     https://github.com/mlr-org/mlr3viz

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3viz 0.1.1.9000
 
-- Internal changes only.
+- `autoplot.BenchmarResult()`: Support for learners with identical IDs (#19)
 
 
 # mlr3viz 0.1.1

--- a/R/BenchmarkResult.R
+++ b/R/BenchmarkResult.R
@@ -36,12 +36,20 @@ autoplot.BenchmarkResult = function(object, type = "boxplot", measure = NULL, ..
 
   task = object$data$task[[1L]]
   measure = mlr3::assert_measure(mlr3::as_measure(measure, task_type = task$task_type), task = task)
+  measure_id = measure$id
   tab = fortify(object, measure = measure)
+  tab$nr = as.character(tab$nr)
+  learner_labels = object$learners$learner_id
 
   switch(type,
     "boxplot" = {
-      ggplot(object, measure = measure, aes_string("learner_id", measure$id)) +
-        geom_boxplot(...) + xlab("") + facet_wrap("task_id")
+      ggplot(tab, mapping = aes(x = .data$nr, y = .data[[measure_id]])) +
+        geom_boxplot(...) +
+        labs(x = "") +
+        scale_x_discrete(labels = learner_labels) +
+        # we need "free_x" to drop empty learners for certain tasks - because
+        # we apply over .data$nr
+        facet_wrap(vars(.data$task_id), scales = "free_x")
     },
 
     "roc" = {


### PR DESCRIPTION
fixes #19 

We still might want to think over requiring unique learner IDs when attempting a BM run in general. This might prevent us from many corner cases where this issue might cause conflicts.

``` r
library(mlr3verse, quietly = TRUE)

lgr::get_logger("mlr3")$set_threshold("warn")
lrn_list = list(
  lrn("classif.featureless"),
  lrn("classif.kknn", predict_type = "prob", k = 3),
  lrn("classif.kknn", predict_type = "prob", k = 10)
)

bm_design1 = benchmark_grid(task = tsks(c("iris", "sonar")),
  resamplings = rsmp("cv", folds = 2), learners = lrn_list)
bmr1 = suppressWarnings(benchmark(bm_design1))
autoplot(bmr1)
```

![](https://i.imgur.com/axbHuua.png)

``` r

bm_design2 = benchmark_grid(task = tsk("sonar"),
  resamplings = rsmp("cv", folds = 2), learners = lrn_list)
bmr2 = suppressWarnings(benchmark(bm_design2))
autoplot(bmr2)
```

![](https://i.imgur.com/QIsbJlm.png)

<sup>Created on 2020-03-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>