### PR TITLE
Update documentation of PredictionRegr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
 Imports:
     checkmate,
     data.table,
-    ggplot2,
+    ggplot2 (>= 3.3.0),
     mlr3misc,
     utils
 Suggests:
@@ -44,4 +44,4 @@ Encoding: UTF-8
 LazyData: true
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -38,40 +38,40 @@
 #' autoplot(object, type = "histogram", binwidth = 1)
 #' autoplot(object, type = "residual")
 autoplot.PredictionRegr = function(object,
-                                   type = "xy",
-                                   ...) {
+  type = "xy",
+  ...) {
   assert_string(type)
 
   switch(type,
-         "xy" = {
-           ggplot(object,
-                  mapping = aes(x = .data[["response"]], y = .data[["truth"]])
-           ) +
-             geom_abline(slope = 1, alpha = 0.5) +
-             geom_point(...) +
-             geom_rug(sides = "bl") +
-             geom_smooth(method = "lm")
-         },
+    "xy" = {
+      ggplot(object,
+        mapping = aes(x = .data[["response"]], y = .data[["truth"]])
+      ) +
+        geom_abline(slope = 1, alpha = 0.5) +
+        geom_point(...) +
+        geom_rug(sides = "bl") +
+        geom_smooth(method = "lm")
+    },
 
-         "histogram" = {
-           object = fortify(object)
-           ggplot(object,
-                  mapping = aes(x = .data[["truth"]] - .data[["response"]],
-                                y = after_stat(density))
-           ) +
-             geom_histogram(...)
-         },
+    "histogram" = {
+      object = fortify(object)
+      ggplot(object,
+        mapping = aes(x = .data[["truth"]] - .data[["response"]],
+          y = after_stat(density))
+      ) +
+        geom_histogram(...)
+    },
 
-         "residual" = {
-           ggplot(object,
-                  mapping = aes(x = .data[["response"]],
-                                y = .data[["truth"]] - .data[["response"]])
-           ) +
-             geom_point(...) +
-             geom_rug(sides = "bl") +
-             geom_smooth(method = "lm")
-         },
+    "residual" = {
+      ggplot(object,
+        mapping = aes(x = .data[["response"]],
+          y = .data[["truth"]] - .data[["response"]])
+      ) +
+        geom_point(...) +
+        geom_rug(sides = "bl") +
+        geom_smooth(method = "lm")
+    },
 
-         stopf("Unknown plot type '%s'", type)
+    stopf("Unknown plot type '%s'", type)
   )
 }

--- a/man/autoplot.PredictionRegr.Rd
+++ b/man/autoplot.PredictionRegr.Rd
@@ -21,10 +21,21 @@ Additional arguments, passed down to the respective \code{geom}.}
 \description{
 Generates plots for \link[mlr3:PredictionRegr]{mlr3::PredictionRegr}, depending on argument \code{type}:
 \itemize{
-\item \code{"xy"} (default): Scatterplot of true response vs predicted response.
-Additionally fits a linear model to visualize a possible trend.
-\item \code{"histogram"}: Histogram of residuals \eqn{r = y - \hat{y}}{r = y - y.hat}.
-\item \code{"residual"}: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
+\item \code{"xy"} (default): Scatterplot of "true" response vs. "predicted" response.
+By default a linear model is fitted via \code{geom_smooth(method = "lm")}
+to visualize the trend between x and y (by default colored blue).
+\itemize{
+\item In addition \code{geom_abline()} with \code{slope = 1} is added to the plot.
+\item Note that \code{geom_smooth()} and \code{geom_abline()} may overlap, depending on the
+given data.
+}
+\item \code{"histogram"}: Histogram of residuals: \eqn{r = y - \hat{y}}{r = y - y.hat}.
+\item \code{"residual"}: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat}
+on the "x" and the residuals on the "y" axis.
+\itemize{
+\item By default a linear model is fitted via \code{geom_smooth(method = "lm")}
+to visualize the trend between x and y (by default colored blue).
+}
 }
 }
 \examples{
@@ -38,4 +49,5 @@ object = learner$train(task)$predict(task)
 head(fortify(object))
 autoplot(object)
 autoplot(object, type = "histogram", binwidth = 1)
+autoplot(object, type = "residual")
 }

--- a/man/mlr3viz-package.Rd
+++ b/man/mlr3viz-package.Rd
@@ -6,12 +6,12 @@
 \alias{mlr3viz-package}
 \title{mlr3viz: Visualizations for 'mlr3'}
 \description{
-Provides visualizations for 'mlr3' objects such as tasks,
-    predictions, resample results or benchmark results via the autoplot()
-    generic of 'ggplot2'. The returned 'ggplot' objects are intended to provide
-    sensible defaults, yet can easily be customized to create camera-ready
-    figures. Visualizations include barplots, boxplots, histograms, ROC curves,
-    and Precision-Recall curves.
+Provides visualizations for 'mlr3' objects such as
+    tasks, predictions, resample results or benchmark results via the
+    autoplot() generic of 'ggplot2'. The returned 'ggplot' objects are
+    intended to provide sensible defaults, yet can easily be customized to
+    create camera-ready figures. Visualizations include barplots,
+    boxplots, histograms, ROC curves, and Precision-Recall curves.
 }
 \seealso{
 Useful links:
@@ -24,5 +24,10 @@ Useful links:
 }
 \author{
 \strong{Maintainer}: Michel Lang \email{michellang@gmail.com} (\href{https://orcid.org/0000-0001-9754-0393}{ORCID})
+
+Authors:
+\itemize{
+  \item Patrick Schratz \email{patrick.schratz@gmail.com} (\href{https://orcid.org/0000-0003-0748-6624}{ORCID})
+}
 
 }


### PR DESCRIPTION
fixes #22 

Also uses the new recommended way to specify "stats" variables (`after_stat()`) and hence we now require ggplot2 v3.3.0.

Also removes `aes_string()` in favor of the recommended `.data` notations.