### PR TITLE
fix show_cb argument for precrec (roc, prc)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Added plots for learners from package `glmnet` via `ggfortify`.
 - Fixed ROC and PRC plots for resampling `"holdout"` (#54).
+- If possible, we show confidence bounds for prc and roc plots (#55).
 
 
 # mlr3viz 0.4.0

--- a/R/helper.R
+++ b/R/helper.R
@@ -21,5 +21,5 @@ plot_precrec = function(object, curvetype = "ROC", cb_alpha = 0.05, ...) {
     cb_alpha = NULL
   }
 
-  autoplot(precrec::evalmod(x, show_cb = show_cb, calc_avg = calc_avg, cb_alpha = cb_alpha), curvetype = curvetype)
+  autoplot(precrec::evalmod(x, calc_avg = calc_avg, cb_alpha = cb_alpha), curvetype = curvetype, show_cb = show_cb)
 }


### PR DESCRIPTION
We passed `show_cb` in the wrong place so the confidence bounds were never truely shown.

Related: Issue #55