### PR TITLE
add dcalib to predictionsurv

### DIFF
--- a/R/PredictionSurv.R
+++ b/R/PredictionSurv.R
@@ -4,10 +4,14 @@
 #' Generates plots for [mlr3proba::PredictionSurv], depending on argument `type`:
 #'
 #' * `"calib"` (default): Calibration plot comparing the average predicted survival distribution
-#'   to a Kaplan-Meier prediction, this is *not* a comparison of a stratified `crank` or `lp`
-#'   prediction. `object` must have `distr` prediction. `geom_line()` is used for comparison split
-#'   between the prediction (`Pred`) and Kaplan-Meier estimate (`KM`). In addition labels are added
-#'   for the x (`T`) and y (`S(T)`) axes.
+#' to a Kaplan-Meier prediction, this is *not* a comparison of a stratified `crank` or `lp`
+#' prediction. `object` must have `distr` prediction. `geom_line()` is used for comparison split
+#'  between the prediction (`Pred`) and Kaplan-Meier estimate (`KM`). In addition labels are added
+#'  for the x (`T`) and y (`S(T)`)
+#' axes.
+#' * `"dcalib"`: Distribution calibration plot. A model is D-calibrated if X% of deaths occur before
+#' the X/100 quantile of the predicted distribution, e.g. if 50% of observations die before their
+#' predicted median survival time. A model is D-calibrated if the resulting plot lies on x = y.
 #'
 #' @param object ([mlr3proba::PredictionSurv]).
 #' @template param_type
@@ -18,8 +22,17 @@
 #' @param times (`numeric()`) \cr
 #'   If `type = "calib"` then `times` is the values on the x-axis to plot over,
 #'    if `NULL` uses all times from `task`.
+#' @param xyline (`logical(1)`) \cr
+#'   If `TRUE` (default) plots the x-y line for `type = "dcalib"`.
+#' @param cuts (`integer(1)`) \cr
+#'   Number of cuts in [0,1] to plot `dcalib` over, default is `11`.
 #' @param ... (`any`):
 #'   Additional arguments, currently unused.
+#'
+#' @references
+#' Haider, H., Hoehn, B., Davis, S., & Greiner, R. (2020).
+#' Effective ways to build and evaluate individual survival distributions.
+#' Journal of Machine Learning Research, 21(85), 1–63.
 #'
 #' @export
 #' @examples
@@ -28,10 +41,20 @@
 #' library(mlr3viz)
 #'
 #' learn = lrn("surv.coxph")
-#' task = tsk("rats")
-#' p = learn$train(task, row_ids = 1:100)$predict(task, row_ids = 101:200)
-#' autoplot(p, type = "calib", task = task)
-autoplot.PredictionSurv = function(object, type = "calib", task = NULL, row_ids = NULL, times = NULL, ...) { # nolint
+#' task = tsk("unemployment")
+#' p = learn$train(task, row_ids = 1:300)$predict(task, row_ids = 301:400)
+#'
+#' # calibration by comparison of average prediction to Kaplan-Meier
+#' autoplot(p, type = "calib", task = task, row_ids = 301:400)
+#'
+#' # Distribution-calibration (D-Calibration)
+#' autoplot(p, type = "dcalib")
+#'
+#' @export
+autoplot.PredictionSurv = function(object, type = c("calib", "dcalib"),
+                                   task = NULL, row_ids = NULL, times = NULL, xyline = TRUE,
+                                   cuts = 11L, ...) {
+
   x = y = Group = NULL
 
   switch(type,
@@ -52,6 +75,17 @@ autoplot.PredictionSurv = function(object, type = "calib", task = NULL, row_ids 
 
       ggplot(data, aes(x = x, y = y, group = Group, color = Group)) + geom_line() +
         labs(x = "T", y = "S(T)")
+    },
+
+    "dcalib" = {
+      p = seq.int(0, 1, length.out = cuts)
+      q = sapply(p, function(.x)
+        sum(object$truth[, 1L] <= as.numeric(object$distr$quantile(.x)))/100)
+      pl = qplot(x = p, y = q, geom = "line")
+      if (xyline) {
+        pl = pl + geom_abline(slope = 1, intercept = 0, color = "red")
+      }
+      pl + labs(x = "True", y = "Predicted")
     },
 
     stopf("Unknown plot type '%s'", type)

--- a/R/PredictionSurv.R
+++ b/R/PredictionSurv.R
@@ -4,14 +4,13 @@
 #' Generates plots for [mlr3proba::PredictionSurv], depending on argument `type`:
 #'
 #' * `"calib"` (default): Calibration plot comparing the average predicted survival distribution
-#' to a Kaplan-Meier prediction, this is *not* a comparison of a stratified `crank` or `lp`
-#' prediction. `object` must have `distr` prediction. `geom_line()` is used for comparison split
-#'  between the prediction (`Pred`) and Kaplan-Meier estimate (`KM`). In addition labels are added
-#'  for the x (`T`) and y (`S(T)`)
-#' axes.
+#'   to a Kaplan-Meier prediction, this is *not* a comparison of a stratified `crank` or `lp`
+#'   prediction. `object` must have `distr` prediction. `geom_line()` is used for comparison split
+#'   between the prediction (`Pred`) and Kaplan-Meier estimate (`KM`). In addition labels are added
+#'   for the x (`T`) and y (`S(T)`) axes.
 #' * `"dcalib"`: Distribution calibration plot. A model is D-calibrated if X% of deaths occur before
-#' the X/100 quantile of the predicted distribution, e.g. if 50% of observations die before their
-#' predicted median survival time. A model is D-calibrated if the resulting plot lies on x = y.
+#'   the X/100 quantile of the predicted distribution, e.g. if 50% of observations die before their
+#'   predicted median survival time. A model is D-calibrated if the resulting plot lies on x = y.
 #'
 #' @param object ([mlr3proba::PredictionSurv]).
 #' @template param_type
@@ -30,9 +29,7 @@
 #'   Additional arguments, currently unused.
 #'
 #' @references
-#' Haider, H., Hoehn, B., Davis, S., & Greiner, R. (2020).
-#' Effective ways to build and evaluate individual survival distributions.
-#' Journal of Machine Learning Research, 21(85), 1–63.
+#' `r format_bib("dcalib")`
 #'
 #' @export
 #' @examples
@@ -49,8 +46,6 @@
 #'
 #' # Distribution-calibration (D-Calibration)
 #' autoplot(p, type = "dcalib")
-#'
-#' @export
 autoplot.PredictionSurv = function(object, type = c("calib", "dcalib"),
                                    task = NULL, row_ids = NULL, times = NULL, xyline = TRUE,
                                    cuts = 11L, ...) {
@@ -79,7 +74,7 @@ autoplot.PredictionSurv = function(object, type = c("calib", "dcalib"),
 
     "dcalib" = {
       p = seq.int(0, 1, length.out = cuts)
-      q = sapply(p, function(.x)
+      q = map_dbl(p, function(.x)
         sum(object$truth[, 1L] <= as.numeric(object$distr$quantile(.x)))/100)
       pl = qplot(x = p, y = q, geom = "line")
       if (xyline) {

--- a/R/PredictionSurv.R
+++ b/R/PredictionSurv.R
@@ -75,7 +75,7 @@ autoplot.PredictionSurv = function(object, type = c("calib", "dcalib"),
     "dcalib" = {
       p = seq.int(0, 1, length.out = cuts)
       q = map_dbl(p, function(.x)
-        sum(object$truth[, 1L] <= as.numeric(object$distr$quantile(.x)))/100)
+        sum(object$truth[, 1L] <= as.numeric(object$distr$quantile(.x)))/length(object$row_ids))
       pl = qplot(x = p, y = q, geom = "line")
       if (xyline) {
         pl = pl + geom_abline(slope = 1, intercept = 0, color = "red")

--- a/R/PredictionSurv.R
+++ b/R/PredictionSurv.R
@@ -25,7 +25,7 @@
 #' @param xyline (`logical(1)`) \cr
 #'   If `TRUE` (default) plots the x-y line for `type = "dcalib"`.
 #' @param cuts (`integer(1)`) \cr
-#'   Number of cuts in [0,1] to plot `dcalib` over, default is `11`.
+#'   Number of cuts in (0,1) to plot `dcalib` over, default is `11`.
 #' @param ... (`any`):
 #'   Additional arguments, currently unused.
 #'

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -25,5 +25,16 @@ bibentries  = c(
     number  = "2",
     volume  = "8",
     doi     = "10.32614/RJ-2016-060"
+  ),
+
+  dcalib = bibentry("article",
+    author  = "Humza Haider and Bret Hoehn and Sarah Davis and Russell Greiner",
+    title   = "Effective Ways to Build and Evaluate Individual Survival Distributions",
+    journal = "Journal of Machine Learning Research",
+    year    = "2020",
+    volume  = "21",
+    number  = "85",
+    pages   = "1-63",
+    url     = "http://jmlr.org/papers/v21/18-772.html"
   )
 )

--- a/man/autoplot.PredictionSurv.Rd
+++ b/man/autoplot.PredictionSurv.Rd
@@ -47,8 +47,7 @@ Generates plots for \link[mlr3proba:PredictionSurv]{mlr3proba::PredictionSurv}, 
 to a Kaplan-Meier prediction, this is \emph{not} a comparison of a stratified \code{crank} or \code{lp}
 prediction. \code{object} must have \code{distr} prediction. \code{geom_line()} is used for comparison split
 between the prediction (\code{Pred}) and Kaplan-Meier estimate (\code{KM}). In addition labels are added
-for the x (\code{T}) and y (\code{S(T)})
-axes.
+for the x (\code{T}) and y (\code{S(T)}) axes.
 \item \code{"dcalib"}: Distribution calibration plot. A model is D-calibrated if X\% of deaths occur before
 the X/100 quantile of the predicted distribution, e.g. if 50\% of observations die before their
 predicted median survival time. A model is D-calibrated if the resulting plot lies on x = y.
@@ -68,10 +67,10 @@ autoplot(p, type = "calib", task = task, row_ids = 301:400)
 
 # Distribution-calibration (D-Calibration)
 autoplot(p, type = "dcalib")
-
 }
 \references{
-Haider, H., Hoehn, B., Davis, S., & Greiner, R. (2020).
-Effective ways to build and evaluate individual survival distributions.
-Journal of Machine Learning Research, 21(85), 1–63.
+Haider H, Hoehn B, Davis S, Greiner R (2020).
+\dQuote{Effective Ways to Build and Evaluate Individual Survival Distributions.}
+\emph{Journal of Machine Learning Research}, \bold{21}(85), 1-63.
+\url{http://jmlr.org/papers/v21/18-772.html}.
 }

--- a/man/autoplot.PredictionSurv.Rd
+++ b/man/autoplot.PredictionSurv.Rd
@@ -6,10 +6,12 @@
 \usage{
 \method{autoplot}{PredictionSurv}(
   object,
-  type = "calib",
+  type = c("calib", "dcalib"),
   task = NULL,
   row_ids = NULL,
   times = NULL,
+  xyline = TRUE,
+  cuts = 11L,
   ...
 )
 }
@@ -29,6 +31,12 @@ If \code{type = "calib"} then \code{row_ids} is passed to \verb{$predict} in the
 If \code{type = "calib"} then \code{times} is the values on the x-axis to plot over,
 if \code{NULL} uses all times from \code{task}.}
 
+\item{xyline}{(\code{logical(1)}) \cr
+If \code{TRUE} (default) plots the x-y line for \code{type = "dcalib"}.}
+
+\item{cuts}{(\code{integer(1)}) \cr
+Number of cuts in \link{0,1} to plot \code{dcalib} over, default is \code{11}.}
+
 \item{...}{(\code{any}):
 Additional arguments, currently unused.}
 }
@@ -39,7 +47,11 @@ Generates plots for \link[mlr3proba:PredictionSurv]{mlr3proba::PredictionSurv}, 
 to a Kaplan-Meier prediction, this is \emph{not} a comparison of a stratified \code{crank} or \code{lp}
 prediction. \code{object} must have \code{distr} prediction. \code{geom_line()} is used for comparison split
 between the prediction (\code{Pred}) and Kaplan-Meier estimate (\code{KM}). In addition labels are added
-for the x (\code{T}) and y (\code{S(T)}) axes.
+for the x (\code{T}) and y (\code{S(T)})
+axes.
+\item \code{"dcalib"}: Distribution calibration plot. A model is D-calibrated if X\% of deaths occur before
+the X/100 quantile of the predicted distribution, e.g. if 50\% of observations die before their
+predicted median survival time. A model is D-calibrated if the resulting plot lies on x = y.
 }
 }
 \examples{
@@ -48,7 +60,18 @@ library(mlr3proba)
 library(mlr3viz)
 
 learn = lrn("surv.coxph")
-task = tsk("rats")
-p = learn$train(task, row_ids = 1:100)$predict(task, row_ids = 101:200)
-autoplot(p, type = "calib", task = task)
+task = tsk("unemployment")
+p = learn$train(task, row_ids = 1:300)$predict(task, row_ids = 301:400)
+
+# calibration by comparison of average prediction to Kaplan-Meier
+autoplot(p, type = "calib", task = task, row_ids = 301:400)
+
+# Distribution-calibration (D-Calibration)
+autoplot(p, type = "dcalib")
+
+}
+\references{
+Haider, H., Hoehn, B., Davis, S., & Greiner, R. (2020).
+Effective ways to build and evaluate individual survival distributions.
+Journal of Machine Learning Research, 21(85), 1–63.
 }

--- a/man/autoplot.PredictionSurv.Rd
+++ b/man/autoplot.PredictionSurv.Rd
@@ -35,7 +35,7 @@ if \code{NULL} uses all times from \code{task}.}
 If \code{TRUE} (default) plots the x-y line for \code{type = "dcalib"}.}
 
 \item{cuts}{(\code{integer(1)}) \cr
-Number of cuts in \link{0,1} to plot \code{dcalib} over, default is \code{11}.}
+Number of cuts in (0,1) to plot \code{dcalib} over, default is \code{11}.}
 
 \item{...}{(\code{any}):
 Additional arguments, currently unused.}

--- a/tests/testthat/test_PredictionSurv.R
+++ b/tests/testthat/test_PredictionSurv.R
@@ -2,7 +2,7 @@ test_that("autoplot.PredictionSurv", {
   skip_if_not_installed("mlr3proba")
   require_namespaces("mlr3proba")
 
-  task = tgen("simsurv")$generate(30L)
+  task = tsk("rats")$filter(1:100)
   learner = lrn("surv.kaplan")$train(task)
   prediction = learner$predict(task)
 

--- a/tests/testthat/test_PredictionSurv.R
+++ b/tests/testthat/test_PredictionSurv.R
@@ -1,0 +1,14 @@
+test_that("autoplot.PredictionSurv", {
+  skip_if_not_installed("mlr3proba")
+  require_namespaces("mlr3proba")
+
+  task = tgen("simsurv")$generate(30L)
+  learner = lrn("surv.kaplan")$train(task)
+  prediction = learner$predict(task)
+
+  p = autoplot(prediction, type = "calib", task = task)
+  expect_true(is.ggplot(p))
+
+  p = autoplot(prediction, type = "dcalib")
+  expect_true(is.ggplot(p))
+})


### PR DESCRIPTION
I would appreciate someone double checking the maths on this one before merging (no rush for this). I haven't seen this used before and it's an extension I've written from a new (2020) measure.

https://www.jmlr.org/papers/volume21/18-772/18-772.pdf - Sec 3.5, the measure itself I'll probably add to proba. The graphical calibration extension is quite nice and intuitive

Basically it plots the following:

x-axis: p = 0,0.1,...,0.9,1 (or with different bin-widths)
y-axis: sum(T_i <= F_i^-1(p))/100
where T_i is individual death-times and F_i^-1 is individual quantile functions.

Model is well-calibrated if this is close to the line x = y.

In words: a model is well-calibrated if 50% of the observations die before their predicted mean survival time and more generally if X% die before X/100 predicted quantile.