### PR TITLE
fix learner label mapping

### DIFF
--- a/R/BenchmarkResult.R
+++ b/R/BenchmarkResult.R
@@ -54,7 +54,9 @@ autoplot.BenchmarkResult = function(object, # nolint
   measure_id = measure$id
   tab = fortify(object, measure = measure)
   tab$nr = as.character(tab$nr)
-  learner_labels = unique(tab$learner_id)
+  learner_label_map = tab[ , list(learner_id = learner_id[1]), by = .(nr)]
+  learner_labels = learner_label_map$learner_id
+  names(learner_labels) = learner_label_map$nr
 
   switch(type,
     "boxplot" = {


### PR DESCRIPTION
Should solve #62 by having a concrete mapping.
Relies on the assumption that for each `nr` only one learner_id is used.

different `nr`s can use the same learner_id. Maybe we want to detect such cases and indicate that with different labels? That would be a usefull improvement?