### PR TITLE
fix plot labelling for >9 experiments

### DIFF
--- a/R/BenchmarkResult.R
+++ b/R/BenchmarkResult.R
@@ -53,7 +53,7 @@ autoplot.BenchmarkResult = function(object, # nolint
     task_type = task$task_type), task = task)
   measure_id = measure$id
   tab = fortify(object, measure = measure)
-  tab$nr = as.character(tab$nr)
+  tab$nr = sprintf("%09d", tab$nr)
   learner_label_map = tab[!duplicated(tab$nr), c("nr", "learner_id")]
   learner_labels = learner_label_map$learner_id
   names(learner_labels) = learner_label_map$nr


### PR DESCRIPTION
Plot labelling for >9 experiments is currently broken because in the character representation of the experiment numbers, 9 comes after 10, 11, etc, which leads to a reordering of the boxes without a corresponding reordering of the labels. Example:

```
library(mlr3)
library(mlr3learners)
library(mlr3viz)

design = benchmark_grid(
    tasks = list(tsk("sonar"), tsk("iris"), tsk("german_credit")),
    learners = list(lrn("classif.featureless"), lrn("classif.log_reg"), lrn("classif.ranger"), lrn("classif.rpart")),
    resamplings = rsmp("cv", folds = 3)
)
bmr = benchmark(design)

print(bmr$aggregate())
autoplot(bmr)
```

In the first panel the featureless learner moves to the end and is mislabelled.

This PR fixes the issue by zero-padding the strings generated from the numbers. Note that this is technically a workaround and will break if someone ever tries to show the results of more than 999,999,999 experiments in one plot.