### PR TITLE
drop row id from [stats::prcomp()] data

### DIFF
--- a/R/PredictionClust.R
+++ b/R/PredictionClust.R
@@ -80,7 +80,7 @@ autoplot.PredictionClust = function(object, task, row_ids = NULL, type = "scatte
         task_data = data.table(task$data(rows = row_ids), row_ids = row_ids)
       }
 
-      plot_data = merge(task_data, d, by = "row_ids")
+      plot_data = merge(task_data, d, by = "row_ids")[, -"row_ids"]
       ggplot2::autoplot(stats::prcomp(task_data),
         data = plot_data,
         colour = "cluster", ...)


### PR DESCRIPTION
`task_data` contain a `row_id` column that is then passed to `stats::prcomp()` to perform pca.

https://github.com/mlr-org/mlr3viz/blob/993bc440d2a14ec261ff5fc9a21800802ddaf01a/R/PredictionClust.R#L77-L88

This inhibits pathologic principal components, especially for scaled data as row_id might scale to large numbers for increasing data sets...