### PR TITLE
Scree plot

### DIFF
--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -11,6 +11,7 @@
 #' Note that learner-specific plots are experimental and subject to change.
 #'
 #' @param object ([mlr3cluster::LearnerClustAgnes] | [mlr3cluster::LearnerClustDiana] | [mlr3cluster::LearnerClustHclust]).
+#' @template param_type
 #' @param ... (`any`):
 #'   Additional arguments, passed down to function [factoextra::fviz_dend()] in package \CRANpkg{factoextra}.
 #'
@@ -57,7 +58,7 @@ autoplot.LearnerClustHierarchical = function(object, type="dend", ...) { # nolin
 
 	"scree" = {
 		data = data.table(Height = object$model$height, Clusters = length(object$model$height):1)
-		ggplot(data, aes(x = Clusters, y = Height)) + geom_point() + geom_line()
+		ggplot(data, aes(x = data$Clusters, y = data$Height)) + geom_point() + geom_line()
 	})
 }
 

--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -30,16 +30,26 @@
 #' autoplot(learner,
 #'   k = learner$param_set$values$k, rect_fill = TRUE,
 #'   rect = TRUE, rect_border = "red")
-autoplot.LearnerClustHierarchical = function(object, ...) { # nolint
+autoplot.LearnerClustHierarchical = function(object, type="dend", ...) { # nolint
+  assert_string(type)
   if (is.null(object$model)) {
     stopf("Learner '%s' must be trained first", object$id)
   }
   if (!("hierarchical" %in% object$properties)) {
     stopf("Learner '%s' must be hierarchical", object$id)
   }
-  require_namespaces("factoextra")
 
-  factoextra::fviz_dend(object$model, horiz = FALSE, ggtheme = theme_gray(), main = NULL, ...)
+  switch(type,
+    "dend" = {
+  	require_namespaces("factoextra")
+
+  	factoextra::fviz_dend(object$model, horiz = FALSE, ggtheme = theme_gray(), main = NULL, ...)
+	}, 
+
+	"scree" = {
+		data = data.table(Height = object$model$height, Clusters = length(object$model$height):1)
+		ggplot(data, aes(x = Clusters, y = Height)) + geom_point() + geom_line()
+	})
 }
 
 #' @export

--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -1,12 +1,16 @@
 #' @title Plot for Hierarchical Clustering Learners
 #'
 #' @description
-#' Visualize dendrograms for hierarchical clusterers
-#' using the package \CRANpkg{factoextra}.
+#' Generates plots for hierarchical clusterers, depending on argument `type`:
+#' 
+#' * `"dend"` (default): dendrograms using \CRANpkg{factoextra} package.
+#' 
+#' * `"scree"`: scree diagram that shows the number of possible clusters on x-axis and 
+#' the height on the y-axis.
 #'
 #' Note that learner-specific plots are experimental and subject to change.
 #'
-#' @param object ([mlr3cluster::LearnerClustAgnes] | [mlr3cluster::LearnerClustDiana]).
+#' @param object ([mlr3cluster::LearnerClustAgnes] | [mlr3cluster::LearnerClustDiana] | [mlr3cluster::LearnerClustHclust]).
 #' @param ... (`any`):
 #'   Additional arguments, passed down to function [factoextra::fviz_dend()] in package \CRANpkg{factoextra}.
 #'

--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -5,7 +5,7 @@
 #' 
 #' * `"dend"` (default): dendrograms using \CRANpkg{factoextra} package.
 #' 
-#' * `"scree"`: scree diagram that shows the number of possible clusters on x-axis and 
+#' * `"scree"`: scree plot that shows the number of possible clusters on x-axis and 
 #' the height on the y-axis.
 #'
 #' Note that learner-specific plots are experimental and subject to change.
@@ -34,6 +34,11 @@
 #' autoplot(learner,
 #'   k = learner$param_set$values$k, rect_fill = TRUE,
 #'   rect = TRUE, rect_border = "red")
+#'
+#' # hclust clustering
+#' learner = mlr_learners$get("clust.hclust")
+#' learner$train(task)
+#' autoplot(learner, type="scree")
 autoplot.LearnerClustHierarchical = function(object, type="dend", ...) { # nolint
   assert_string(type)
   if (is.null(object$model)) {

--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -51,16 +51,16 @@ autoplot.LearnerClustHierarchical = function(object, type="dend", ...) { # nolin
 
   switch(type,
     "dend" = {
-  	require_namespaces("factoextra")
+    require_namespaces("factoextra")
 
-  	factoextra::fviz_dend(object$model, horiz = FALSE, ggtheme = theme_gray(), main = NULL, ...)
-	}, 
+    factoextra::fviz_dend(object$model, horiz = FALSE, ggtheme = theme_gray(), main = NULL, ...)
+  }, 
 
-	"scree" = {
-		data = data.table(Height = object$model$height, Clusters = length(object$model$height):1)
-		ggplot(data, aes(x = data$Clusters, y = data$Height)) + geom_point() + geom_line() + 
-			xlab("Clusters") + ylab("Height")
-	})
+  "scree" = {
+    data = data.table(Height = object$model$height, Clusters = length(object$model$height):1)
+    ggplot(data, aes(x = data$Clusters, y = data$Height)) + geom_point() + geom_line() + 
+      xlab("Clusters") + ylab("Height")
+  })
 }
 
 #' @export

--- a/R/LearnerClustHierarchical.R
+++ b/R/LearnerClustHierarchical.R
@@ -58,7 +58,8 @@ autoplot.LearnerClustHierarchical = function(object, type="dend", ...) { # nolin
 
 	"scree" = {
 		data = data.table(Height = object$model$height, Clusters = length(object$model$height):1)
-		ggplot(data, aes(x = data$Clusters, y = data$Height)) + geom_point() + geom_line()
+		ggplot(data, aes(x = data$Clusters, y = data$Height)) + geom_point() + geom_line() + 
+			xlab("Clusters") + ylab("Height")
 	})
 }
 

--- a/man/autoplot.LearnerClustHierarchical.Rd
+++ b/man/autoplot.LearnerClustHierarchical.Rd
@@ -19,7 +19,7 @@ Additional arguments, passed down to function \code{\link[factoextra:fviz_dend]{
 Generates plots for hierarchical clusterers, depending on argument \code{type}:
 \itemize{
 \item \code{"dend"} (default): dendrograms using \CRANpkg{factoextra} package.
-\item \code{"scree"}: scree diagram that shows the number of possible clusters on x-axis and
+\item \code{"scree"}: scree plot that shows the number of possible clusters on x-axis and
 the height on the y-axis.
 }
 
@@ -43,4 +43,9 @@ learner$train(task)
 autoplot(learner,
   k = learner$param_set$values$k, rect_fill = TRUE,
   rect = TRUE, rect_border = "red")
+
+# hclust clustering
+learner = mlr_learners$get("clust.hclust")
+learner$train(task)
+autoplot(learner, type="scree")
 }

--- a/man/autoplot.LearnerClustHierarchical.Rd
+++ b/man/autoplot.LearnerClustHierarchical.Rd
@@ -9,6 +9,9 @@
 \arguments{
 \item{object}{(\link[mlr3cluster:mlr_learners_clust.agnes]{mlr3cluster::LearnerClustAgnes} | \link[mlr3cluster:mlr_learners_clust.diana]{mlr3cluster::LearnerClustDiana} | \link[mlr3cluster:mlr_learners_clust.hclust]{mlr3cluster::LearnerClustHclust}).}
 
+\item{type}{(character(1)):\cr
+Type of the plot. See description.}
+
 \item{...}{(\code{any}):
 Additional arguments, passed down to function \code{\link[factoextra:fviz_dend]{factoextra::fviz_dend()}} in package \CRANpkg{factoextra}.}
 }

--- a/man/autoplot.LearnerClustHierarchical.Rd
+++ b/man/autoplot.LearnerClustHierarchical.Rd
@@ -4,10 +4,10 @@
 \alias{autoplot.LearnerClustHierarchical}
 \title{Plot for Hierarchical Clustering Learners}
 \usage{
-\method{autoplot}{LearnerClustHierarchical}(object, ...)
+\method{autoplot}{LearnerClustHierarchical}(object, type = "dend", ...)
 }
 \arguments{
-\item{object}{(\link[mlr3cluster:mlr_learners_clust.agnes]{mlr3cluster::LearnerClustAgnes} | \link[mlr3cluster:mlr_learners_clust.diana]{mlr3cluster::LearnerClustDiana}).}
+\item{object}{(\link[mlr3cluster:mlr_learners_clust.agnes]{mlr3cluster::LearnerClustAgnes} | \link[mlr3cluster:mlr_learners_clust.diana]{mlr3cluster::LearnerClustDiana} | \link[mlr3cluster:mlr_learners_clust.hclust]{mlr3cluster::LearnerClustHclust}).}
 
 \item{...}{(\code{any}):
 Additional arguments, passed down to function \code{\link[factoextra:fviz_dend]{factoextra::fviz_dend()}} in package \CRANpkg{factoextra}.}
@@ -16,8 +16,12 @@ Additional arguments, passed down to function \code{\link[factoextra:fviz_dend]{
 \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 }
 \description{
-Visualize dendrograms for hierarchical clusterers
-using the package \CRANpkg{factoextra}.
+Generates plots for hierarchical clusterers, depending on argument \code{type}:
+\itemize{
+\item \code{"dend"} (default): dendrograms using \CRANpkg{factoextra} package.
+\item \code{"scree"}: scree diagram that shows the number of possible clusters on x-axis and
+the height on the y-axis.
+}
 
 Note that learner-specific plots are experimental and subject to change.
 }

--- a/tests/testthat/_snaps/LearnerClustHierarchical/learner-clust-hclust.svg
+++ b/tests/testthat/_snaps/LearnerClustHierarchical/learner-clust-hclust.svg
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='37.69' y='22.78' width='676.83' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='37.69' y='22.78' width='676.83' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='683.76' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='670.94' cy='518.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='658.12' cy='518.70' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='645.30' cy='514.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='632.48' cy='514.29' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='619.66' cy='513.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='606.84' cy='512.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='594.02' cy='511.19' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='581.21' cy='507.40' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='568.39' cy='506.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='555.57' cy='504.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='542.75' cy='504.54' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='529.93' cy='504.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='517.11' cy='503.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='504.29' cy='503.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.47' cy='503.35' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='478.65' cy='502.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='465.84' cy='501.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='453.02' cy='499.99' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='440.20' cy='499.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='427.38' cy='499.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='414.56' cy='499.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='401.74' cy='497.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='388.92' cy='495.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='376.10' cy='493.42' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='363.29' cy='492.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='350.47' cy='490.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='337.65' cy='488.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='324.83' cy='488.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='312.01' cy='484.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='299.19' cy='484.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='286.37' cy='478.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='273.55' cy='477.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='260.74' cy='473.80' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='247.92' cy='473.57' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='235.10' cy='471.78' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='222.28' cy='465.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='209.46' cy='465.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='196.64' cy='462.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='183.82' cy='457.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='171.00' cy='445.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.18' cy='437.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='145.37' cy='431.76' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='132.55' cy='419.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='119.73' cy='413.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='106.91' cy='382.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='94.09' cy='357.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='81.27' cy='250.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='68.45' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<polyline points='68.45,46.53 81.27,250.28 94.09,357.45 106.91,382.77 119.73,413.03 132.55,419.17 145.37,431.76 158.18,437.75 171.00,445.69 183.82,457.48 196.64,462.31 209.46,465.05 222.28,465.23 235.10,471.78 247.92,473.57 260.74,473.80 273.55,477.43 286.37,478.43 299.19,484.21 312.01,484.53 324.83,488.00 337.65,488.65 350.47,490.60 363.29,492.66 376.10,493.42 388.92,495.33 401.74,497.43 414.56,499.21 427.38,499.63 440.20,499.92 453.02,499.99 465.84,501.47 478.65,502.46 491.47,503.35 504.29,503.43 517.11,503.84 529.93,504.28 542.75,504.54 555.57,504.85 568.39,506.43 581.21,507.40 594.02,511.19 606.84,512.02 619.66,513.12 632.48,514.29 645.30,514.94 658.12,518.70 670.94,518.86 683.76,521.37 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='37.69' y='22.78' width='676.83' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='32.76' y='528.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='32.76' y='365.14' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='32.76' y='202.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='32.76' y='39.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<polyline points='34.95,525.10 37.69,525.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,362.11 37.69,362.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,199.12 37.69,199.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,36.13 37.69,36.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='55.63,547.85 55.63,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='183.82,547.85 183.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='312.01,547.85 312.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='440.20,547.85 440.20,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='568.39,547.85 568.39,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='696.57,547.85 696.57,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='55.63' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='183.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='312.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='440.20' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='568.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='696.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='376.10' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>Clusters</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Height</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='113.74px' lengthAdjust='spacingAndGlyphs'>learner_clust.hclust</text>
+</g>
+</svg>

--- a/tests/testthat/test_LearnerClustHierarchical.R
+++ b/tests/testthat/test_LearnerClustHierarchical.R
@@ -9,4 +9,9 @@ test_that("autoplot.LearnerClustHierarchical", {
   p = autoplot(learner)
   expect_true(is.ggplot(p))
   vdiffr::expect_doppelganger("learner_clust.agnes", p)
+
+  learner = mlr3::lrn("clust.hclust")$train(mlr3::tsk("usarrests"))
+  p = autoplot(learner, type="scree")
+  expect_true(is.ggplot(p))
+  vdiffr::expect_doppelganger("learner_clust.hclust", p)
 })


### PR DESCRIPTION
I added an option to create scree plots for hierarchical clustering learners. A scree plot can help choose optimal number of clusters.

```
library(mlr3)
library(mlr3cluster)
library(mlr3viz)

task = tsk("usarrests")
learner = lrn("clust.hclust")
learner$train(task)
autoplot(learner, type="scree")
```


![scree](https://user-images.githubusercontent.com/31703384/141406531-2e923850-e631-4389-a94f-c6742275b0e2.png)
