### PR TITLE
Less pre-commit convolution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,6 @@ repos:
         language: fail
         files: '\.Rhistory|\.RData|\.Rds|\.rds$'
         # `exclude: <regex>` to allow committing specific files.
+
+ci:
+    autoupdate_schedule: monthly


### PR DESCRIPTION
Only run pre-commit hooks (and autoupdate) once a month in the cloud, not every week.