### PR TITLE
add confidence interval plot for regr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ renv.lock
 
 # revdep
 revdep/
+check/*

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -12,11 +12,16 @@
 #' * `"histogram"`: Histogram of residuals: \eqn{r = y - \hat{y}}{r = y - y.hat}.
 #' * `"residual"`: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 #'    By default a linear model is fitted via `geom_smooth(method = "lm")` to visualize the trend between x and y (by default colored blue).
+#' * `"confidence`: Scatterplot of "true" response vs. "predicted" response with
+#'    confidence intervals. Error bars calculated as object$reponse ± object$se and so only
+#'    possible with `predict_type = "se"`. `geom_abline()` with `slope = 1` is added to the plot.
 #'
 #' @param object ([mlr3::PredictionRegr]).
 #' @template param_type
 #' @param binwidth (`integer(1)`)\cr
 #'  Width of the bins for the histogram.
+#' @param quantile (`numeric(1)`)\cr
+#'  Quantile multiplier for standard errors for `type="confidence"`. Default 1.96.
 #' @template param_theme
 #' @param ... (ignored).
 #'
@@ -36,8 +41,15 @@
 #'   autoplot(object)
 #'   autoplot(object, type = "histogram", binwidth = 1)
 #'   autoplot(object, type = "residual")
+#'
+#'  if (requireNamespace("mlr3learners")) {
+#'   library(mlr3learners)
+#'   learner = lrn("regr.ranger", predict_type = "se")
+#'   object = learner$train(task)$predict(task)
+#'   autoplot(object, type = "confidence")
+#'  }
 #' }
-autoplot.PredictionRegr = function(object, type = "xy", binwidth = NULL, theme = theme_minimal(), ...) {
+autoplot.PredictionRegr = function(object, type = "xy", binwidth = NULL, theme = theme_minimal(), quantile = 1.96, ...) {
   checkmate::assert_string(type)
 
   switch(type,
@@ -92,6 +104,35 @@ autoplot.PredictionRegr = function(object, type = "xy", binwidth = NULL, theme =
           color = viridis::viridis(1, begin = 0.5)) +
         xlab("Response") +
         ylab("Residuals") +
+        theme
+    },
+
+    "confidence" = {
+      if (allMissing(object$se)) {
+        stop("Plot type 'confidence' only possible when `predict_type = 'se'`")
+      }
+
+      df = data.frame(
+        lower = object$response - quantile * object$se,
+        central = object$response,
+        upper =  object$response + quantile * object$se, truth = object$truth)
+
+      ggplot(df,
+        mapping = aes(
+          x = .data[["central"]],
+          xmin = .data[["lower"]],
+          xmax = .data[["upper"]],
+          y = .data[["truth"]])) +
+        geom_abline(
+          slope = 1,
+          alpha = 0.5) +
+        geom_point(
+          color = viridis::viridis(1, begin = 0.33),
+          alpha = 0.8
+        ) +
+        geom_linerange() +
+        xlab(sprintf("Response ± %sse", quantile)) +
+        ylab("Truth") +
         theme
     },
 

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -13,7 +13,7 @@
 #' * `"residual"`: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 #'    By default a linear model is fitted via `geom_smooth(method = "lm")` to visualize the trend between x and y (by default colored blue).
 #' * `"confidence`: Scatterplot of "true" response vs. "predicted" response with
-#'    confidence intervals. Error bars calculated as object$reponse +- object$se and so only
+#'    confidence intervals. Error bars calculated as object$reponse +- quantile * object$se and so only
 #'    possible with `predict_type = "se"`. `geom_abline()` with `slope = 1` is added to the plot.
 #'
 #' @param object ([mlr3::PredictionRegr]).

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -125,12 +125,12 @@ autoplot.PredictionRegr = function(object, type = "xy", binwidth = NULL, theme =
           y = .data[["truth"]])) +
         geom_abline(
           slope = 1,
-          alpha = 0.5) +
+          colour = "grey",
+          linetype = 3) +
+        geom_linerange(color = viridis::viridis(1, begin = 0.33)) +
         geom_point(
-          color = viridis::viridis(1, begin = 0.33),
-          alpha = 0.8
-        ) +
-        geom_linerange() +
+          color = viridis::viridis(1, begin = 0.5),
+          alpha = 0.8) +
         xlab(sprintf("Response \u00B1 %sse", quantile)) +
         ylab("Truth") +
         theme

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -13,7 +13,7 @@
 #' * `"residual"`: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 #'    By default a linear model is fitted via `geom_smooth(method = "lm")` to visualize the trend between x and y (by default colored blue).
 #' * `"confidence`: Scatterplot of "true" response vs. "predicted" response with
-#'    confidence intervals. Error bars calculated as object$reponse ± object$se and so only
+#'    confidence intervals. Error bars calculated as object$reponse +- object$se and so only
 #'    possible with `predict_type = "se"`. `geom_abline()` with `slope = 1` is added to the plot.
 #'
 #' @param object ([mlr3::PredictionRegr]).
@@ -131,7 +131,7 @@ autoplot.PredictionRegr = function(object, type = "xy", binwidth = NULL, theme =
           alpha = 0.8
         ) +
         geom_linerange() +
-        xlab(sprintf("Response ± %sse", quantile)) +
+        xlab(sprintf("Response \u00B1 %sse", quantile)) +
         ylab("Truth") +
         theme
     },

--- a/man/autoplot.PredictionRegr.Rd
+++ b/man/autoplot.PredictionRegr.Rd
@@ -4,7 +4,14 @@
 \alias{autoplot.PredictionRegr}
 \title{Plots for Regression Predictions}
 \usage{
-\method{autoplot}{PredictionRegr}(object, type = "xy", binwidth = NULL, theme = theme_minimal(), ...)
+\method{autoplot}{PredictionRegr}(
+  object,
+  type = "xy",
+  binwidth = NULL,
+  theme = theme_minimal(),
+  quantile = 1.96,
+  ...
+)
 }
 \arguments{
 \item{object}{(\link[mlr3:PredictionRegr]{mlr3::PredictionRegr}).}
@@ -17,6 +24,9 @@ Width of the bins for the histogram.}
 
 \item{theme}{(\code{\link[ggplot2:theme]{ggplot2::theme()}})\cr
 The \code{\link[ggplot2:ggtheme]{ggplot2::theme_minimal()}} is applied by default to all plots.}
+
+\item{quantile}{(\code{numeric(1)})\cr
+Quantile multiplier for standard errors for \code{type="confidence"}. Default 1.96.}
 
 \item{...}{(ignored).}
 }
@@ -35,6 +45,9 @@ Note that \code{geom_smooth()} and \code{geom_abline()} may overlap, depending o
 \item \code{"histogram"}: Histogram of residuals: \eqn{r = y - \hat{y}}{r = y - y.hat}.
 \item \code{"residual"}: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 By default a linear model is fitted via \code{geom_smooth(method = "lm")} to visualize the trend between x and y (by default colored blue).
+\item \verb{"confidence}: Scatterplot of "true" response vs. "predicted" response with
+confidence intervals. Error bars calculated as object$reponse ± object$se and so only
+possible with \code{predict_type = "se"}. \code{geom_abline()} with \code{slope = 1} is added to the plot.
 }
 }
 \examples{
@@ -50,5 +63,12 @@ if (requireNamespace("mlr3")) {
   autoplot(object)
   autoplot(object, type = "histogram", binwidth = 1)
   autoplot(object, type = "residual")
+
+ if (requireNamespace("mlr3learners")) {
+  library(mlr3learners)
+  learner = lrn("regr.ranger", predict_type = "se")
+  object = learner$train(task)$predict(task)
+  autoplot(object, type = "confidence")
+ }
 }
 }

--- a/man/autoplot.PredictionRegr.Rd
+++ b/man/autoplot.PredictionRegr.Rd
@@ -46,7 +46,7 @@ Note that \code{geom_smooth()} and \code{geom_abline()} may overlap, depending o
 \item \code{"residual"}: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 By default a linear model is fitted via \code{geom_smooth(method = "lm")} to visualize the trend between x and y (by default colored blue).
 \item \verb{"confidence}: Scatterplot of "true" response vs. "predicted" response with
-confidence intervals. Error bars calculated as object$reponse ± object$se and so only
+confidence intervals. Error bars calculated as object$reponse +- object$se and so only
 possible with \code{predict_type = "se"}. \code{geom_abline()} with \code{slope = 1} is added to the plot.
 }
 }

--- a/man/autoplot.PredictionRegr.Rd
+++ b/man/autoplot.PredictionRegr.Rd
@@ -46,7 +46,7 @@ Note that \code{geom_smooth()} and \code{geom_abline()} may overlap, depending o
 \item \code{"residual"}: Plot of the residuals, with the response \eqn{\hat{y}}{y.hat} on the "x" and the residuals on the "y" axis.
 By default a linear model is fitted via \code{geom_smooth(method = "lm")} to visualize the trend between x and y (by default colored blue).
 \item \verb{"confidence}: Scatterplot of "true" response vs. "predicted" response with
-confidence intervals. Error bars calculated as object$reponse +- object$se and so only
+confidence intervals. Error bars calculated as object$reponse +- quantile * object$se and so only
 possible with \code{predict_type = "se"}. \code{geom_abline()} with \code{slope = 1} is added to the plot.
 }
 }

--- a/tests/testthat/_snaps/PredictionRegr/predictionregr-confidence.svg
+++ b/tests/testthat/_snaps/PredictionRegr/predictionregr-confidence.svg
@@ -47,71 +47,71 @@
 <polyline points='371.28,545.11 371.28,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='502.44,545.11 502.44,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='633.60,545.11 633.60,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='-648.93' y1='1113.24' x2='1396.25' y2='-462.12' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.50; stroke-linecap: butt;' />
-<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
-<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='353.66' x2='683.53' y2='353.66' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='365.78' x2='683.53' y2='365.78' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='442.57' x2='683.53' y2='442.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='238.48' x2='683.53' y2='238.48' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='371.84' x2='683.53' y2='371.84' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='400.13' x2='683.53' y2='400.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='381.95' x2='683.53' y2='381.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='434.48' x2='683.53' y2='434.48' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='76.83' x2='683.53' y2='76.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='46.53' x2='683.53' y2='46.53' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='297.08' x2='683.53' y2='297.08' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='418.32' x2='683.53' y2='418.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='462.77' x2='683.53' y2='462.77' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='179.89' x2='683.53' y2='179.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='206.15' x2='683.53' y2='206.15' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='412.26' x2='683.53' y2='412.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='333.45' x2='683.53' y2='333.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='428.42' x2='683.53' y2='428.42' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='-648.93' y1='1113.24' x2='1396.25' y2='-462.12' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='353.66' x2='683.53' y2='353.66' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='365.78' x2='683.53' y2='365.78' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='442.57' x2='683.53' y2='442.57' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='238.48' x2='683.53' y2='238.48' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='371.84' x2='683.53' y2='371.84' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='400.13' x2='683.53' y2='400.13' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='381.95' x2='683.53' y2='381.95' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='434.48' x2='683.53' y2='434.48' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='76.83' x2='683.53' y2='76.83' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='46.53' x2='683.53' y2='46.53' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='297.08' x2='683.53' y2='297.08' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='418.32' x2='683.53' y2='418.32' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='462.77' x2='683.53' y2='462.77' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='179.89' x2='683.53' y2='179.89' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='206.15' x2='683.53' y2='206.15' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='412.26' x2='683.53' y2='412.26' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='333.45' x2='683.53' y2='333.45' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='428.42' x2='683.53' y2='428.42' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke: #31678E; stroke-linecap: butt;' />
+<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #21908C; stroke-opacity: 0.80; fill: #21908C; fill-opacity: 0.80;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>

--- a/tests/testthat/_snaps/PredictionRegr/predictionregr-confidence.svg
+++ b/tests/testthat/_snaps/PredictionRegr/predictionregr-confidence.svg
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<polyline points='32.79,478.94 714.52,478.94 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,377.91 714.52,377.91 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,276.88 714.52,276.88 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,175.85 714.52,175.85 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,74.81 714.52,74.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='43.38,545.11 43.38,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='174.54,545.11 174.54,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='305.70,545.11 305.70,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='436.86,545.11 436.86,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.02,545.11 568.02,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='699.18,545.11 699.18,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,529.45 714.52,529.45 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,428.42 714.52,428.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,327.39 714.52,327.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,226.36 714.52,226.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,125.33 714.52,125.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='32.79,24.30 714.52,24.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='108.96,545.11 108.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='240.12,545.11 240.12,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='371.28,545.11 371.28,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='502.44,545.11 502.44,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='633.60,545.11 633.60,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='-648.93' y1='1113.24' x2='1396.25' y2='-462.12' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.50; stroke-linecap: butt;' />
+<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<circle cx='373.66' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #31678E; stroke-opacity: 0.80; fill: #31678E; fill-opacity: 0.80;' />
+<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='307.19' x2='683.53' y2='307.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='353.66' x2='683.53' y2='353.66' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='365.78' x2='683.53' y2='365.78' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='442.57' x2='683.53' y2='442.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='238.48' x2='683.53' y2='238.48' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='270.81' x2='683.53' y2='270.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='371.84' x2='683.53' y2='371.84' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='400.13' x2='683.53' y2='400.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='381.95' x2='683.53' y2='381.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='521.37' x2='683.53' y2='521.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='434.48' x2='683.53' y2='434.48' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='76.83' x2='683.53' y2='76.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='46.53' x2='683.53' y2='46.53' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='297.08' x2='683.53' y2='297.08' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='418.32' x2='683.53' y2='418.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='424.38' x2='683.53' y2='424.38' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='462.77' x2='683.53' y2='462.77' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='343.56' x2='683.53' y2='343.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='179.89' x2='683.53' y2='179.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='206.15' x2='683.53' y2='206.15' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='117.25' x2='683.53' y2='117.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='412.26' x2='683.53' y2='412.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='333.45' x2='683.53' y2='333.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='428.42' x2='683.53' y2='428.42' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='63.78' y1='299.10' x2='683.53' y2='299.10' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='431.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='330.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='229.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='128.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='27.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='108.96' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='240.12' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='371.28' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='502.44' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='633.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='94.73px' lengthAdjust='spacingAndGlyphs'>Response ± 1.96se</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='25.67px' lengthAdjust='spacingAndGlyphs'>Truth</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='151.91px' lengthAdjust='spacingAndGlyphs'>predictionregr_confidence</text>
+</g>
+</svg>

--- a/tests/testthat/test_PredictionRegr.R
+++ b/tests/testthat/test_PredictionRegr.R
@@ -16,4 +16,10 @@ test_that("autoplot.PredictionRegr", {
   p = autoplot(prediction, type = "residual")
   expect_true(is.ggplot(p))
   expect_doppelganger("predictionregr_residual", p)
+
+  learner = mlr3::lrn("regr.featureless", predict_type = "se")$train(task)
+  prediction = learner$predict(task)
+  p = autoplot(prediction, type = "confidence")
+  expect_true(is.ggplot(p))
+  expect_doppelganger("predictionregr_confidence", p)
 })


### PR DESCRIPTION
Hi @mllg I've added a plot to visualise predictions when `predict_type = "se"`. Doesn't require any new dependencies and just uses mlr3. Example plot:
![Screenshot 2023-02-10 at 09 47 39](https://user-images.githubusercontent.com/25639974/218059567-ab64b513-9cff-4a25-ba58-681e616cd25b.png)
